### PR TITLE
Respond method not found error

### DIFF
--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
@@ -58,6 +58,6 @@ object Models {
     lazy val internalError = JsonRpcError(-32603, "Internal error", Option("Internal JSON-RPC error."))
   }
 
-  class JsonRpcException[+ERROR](val response: JsonRpcErrorResponse[ERROR]) extends RuntimeException
+  class JsonRpcException[+ERROR](val maybeResponse: Option[JsonRpcErrorResponse[ERROR]]) extends RuntimeException
 
 }

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
@@ -6,7 +6,7 @@ object Models {
 
   case class JsonRpcMethod(jsonrpc: String, method: String)
 
-  case class JsonRpcRequestId(id: Either[String, BigDecimal])
+  case class JsonRpcRequestId(jsonrpc: String, id: Either[String, BigDecimal])
 
   case class JsonRpcRequest[PARAMS]
   (
@@ -58,6 +58,6 @@ object Models {
     lazy val internalError = JsonRpcError(-32603, "Internal error", Option("Internal JSON-RPC error."))
   }
 
-  class JsonRpcErrorException[+ERROR](val response: JsonRpcErrorResponse[ERROR]) extends RuntimeException
+  class JsonRpcException[+ERROR](val response: JsonRpcErrorResponse[ERROR]) extends RuntimeException
 
 }

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/Models.scala
@@ -6,6 +6,8 @@ object Models {
 
   case class JsonRpcMethod(jsonrpc: String, method: String)
 
+  case class JsonRpcRequestId(id: Either[String, BigDecimal])
+
   case class JsonRpcRequest[PARAMS]
   (
       jsonrpc: String,
@@ -34,34 +36,28 @@ object Models {
       result: RESULT
   )
 
-  case class JsonRpcErrorResponse[ERROR]
+  case class JsonRpcErrorResponse[+ERROR]
   (
       jsonrpc: String,
       id: Either[String, BigDecimal],
       error: JsonRpcError[ERROR]
   )
 
-  case class JsonRpcError[ERROR]
+  case class JsonRpcError[+ERROR]
   (
       code: Int,
       message: String,
       data: Option[ERROR]
   )
 
-  object JsonRpcError {
-    def apply(code: Int, message: String): JsonRpcError[String] =
-      JsonRpcError[String](code, message, None)
-
-    def apply[ERROR](code: Int, message: String, data: ERROR): JsonRpcError[ERROR] =
-      JsonRpcError[ERROR](code, message, Option(data))
-  }
-
   object JsonRpcErrors {
-    lazy val parseError = JsonRpcError(-32700, "Parse error", "Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.")
-    lazy val invalidRequest = JsonRpcError(-32600, "Invalid Request", "The JSON sent is not a valid Request object.")
-    lazy val methodNotFound = JsonRpcError(-32601, "Method not found", "The method does not exist / is not available.")
-    lazy val invalidParams = JsonRpcError(-32602, "Invalid params", "Invalid method parameter(s).")
-    lazy val internalError = JsonRpcError(-32603, "Internal error", "Internal JSON-RPC error.")
+    lazy val parseError = JsonRpcError(-32700, "Parse error", Option("Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text."))
+    lazy val invalidRequest = JsonRpcError(-32600, "Invalid Request", Option("The JSON sent is not a valid Request object."))
+    lazy val methodNotFound = JsonRpcError(-32601, "Method not found", Option("The method does not exist / is not available."))
+    lazy val invalidParams = JsonRpcError(-32602, "Invalid params", Option("Invalid method parameter(s)."))
+    lazy val internalError = JsonRpcError(-32603, "Internal error", Option("Internal JSON-RPC error."))
   }
+
+  class JsonRpcErrorException[+ERROR](val response: JsonRpcErrorResponse[ERROR]) extends RuntimeException
 
 }

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
@@ -5,7 +5,7 @@ import io.github.shogowada.scala.jsonrpc.Types.JsonSender
 import io.github.shogowada.scala.jsonrpc.serializers.JsonSerializer
 import io.github.shogowada.scala.jsonrpc.utils.MacroUtils
 
-import scala.concurrent.{Future, Promise}
+import scala.concurrent.Promise
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
@@ -178,7 +178,7 @@ object JsonRpcClientMacro {
     val jsonSerializer: Tree = q"${c.prefix.tree}.jsonSerializer"
     val promisedResponseRepository: Tree = q"${c.prefix.tree}.promisedResponseRepository"
 
-    val maybeJsonRpcRequestId = c.Expr[JsonRpcRequestId](
+    val maybeJsonRpcRequestId = c.Expr[Option[JsonRpcRequestId]](
       q"""
           $jsonSerializer.deserialize[JsonRpcRequestId]($json)
               .filter(requestId => requestId.jsonrpc == Constants.JsonRpc)

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
@@ -142,13 +142,10 @@ object JsonRpcClientMacro {
                 .map((json: String) => {
                   $jsonSerializer.deserialize[JsonRpcResultResponse[$resultType]](json)
                       .map(resultResponse => resultResponse.result)
-                      .orElse {
-                        $jsonSerializer.deserialize[JsonRpcErrorResponse[String]](json)
-                          .map(errorResponse => {
-                            throw new JsonRpcException(errorResponse)
-                          })
+                      .getOrElse {
+                        val maybeResponse = $jsonSerializer.deserialize[JsonRpcErrorResponse[String]](json)
+                        throw new JsonRpcException(maybeResponse)
                       }
-                      .get
                 })
             """
       )

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
@@ -1,5 +1,6 @@
 package io.github.shogowada.scala.jsonrpc
 
+import io.github.shogowada.scala.jsonrpc.Models.{JsonRpcErrorException, JsonRpcErrorResponse, JsonRpcErrors}
 import io.github.shogowada.scala.jsonrpc.client.JsonRpcClientBuilder
 import io.github.shogowada.scala.jsonrpc.serializers.UpickleJsonSerializer
 import io.github.shogowada.scala.jsonrpc.server.JsonRpcServerBuilder
@@ -88,6 +89,29 @@ class ClientAndServerTest extends AsyncFunSpec
 
         it("then it should greet the server") {
           greeterApiServer.greetings should equal(List(greeting))
+        }
+      }
+    }
+
+    describe("when I am using invalid API") {
+      trait InvalidApi {
+        def invalidRequest: Future[String]
+      }
+
+      val invalidApi = client.createApi[InvalidApi]
+
+      describe("when I send request") {
+        val response = invalidApi.invalidRequest
+        it("then it should response error") {
+          response.failed
+              .map {
+                case exception: JsonRpcErrorException[_] => {
+                  exception.response should matchPattern {
+                    case JsonRpcErrorResponse(Constants.JsonRpc, _, JsonRpcErrors.methodNotFound) =>
+                  }
+                }
+                case _ => fail("It should have failed with JsonRpcErrorException")
+              }
         }
       }
     }

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
@@ -106,8 +106,8 @@ class ClientAndServerTest extends AsyncFunSpec
           response.failed
               .map {
                 case exception: JsonRpcException[_] => {
-                  exception.response should matchPattern {
-                    case JsonRpcErrorResponse(Constants.JsonRpc, _, JsonRpcErrors.methodNotFound) =>
+                  exception.maybeResponse should matchPattern {
+                    case Some(JsonRpcErrorResponse(Constants.JsonRpc, _, JsonRpcErrors.methodNotFound)) =>
                   }
                 }
                 case exception => fail("It should have failed with JsonRpcErrorException, but failed with " + exception)

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/ClientAndServerTest.scala
@@ -1,6 +1,6 @@
 package io.github.shogowada.scala.jsonrpc
 
-import io.github.shogowada.scala.jsonrpc.Models.{JsonRpcErrorException, JsonRpcErrorResponse, JsonRpcErrors}
+import io.github.shogowada.scala.jsonrpc.Models.{JsonRpcErrorResponse, JsonRpcErrors, JsonRpcException}
 import io.github.shogowada.scala.jsonrpc.client.JsonRpcClientBuilder
 import io.github.shogowada.scala.jsonrpc.serializers.UpickleJsonSerializer
 import io.github.shogowada.scala.jsonrpc.server.JsonRpcServerBuilder
@@ -105,12 +105,12 @@ class ClientAndServerTest extends AsyncFunSpec
         it("then it should response error") {
           response.failed
               .map {
-                case exception: JsonRpcErrorException[_] => {
+                case exception: JsonRpcException[_] => {
                   exception.response should matchPattern {
                     case JsonRpcErrorResponse(Constants.JsonRpc, _, JsonRpcErrors.methodNotFound) =>
                   }
                 }
-                case _ => fail("It should have failed with JsonRpcErrorException")
+                case exception => fail("It should have failed with JsonRpcErrorException, but failed with " + exception)
               }
         }
       }

--- a/upickle-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/UpickleJsonSerializer.scala
+++ b/upickle-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/UpickleJsonSerializer.scala
@@ -20,8 +20,9 @@ object UpickleJsonSerializerMacro {
 
     c.Expr[Option[String]](
       q"""
+          import scala.util.Try
           import upickle.default._
-          Option(write($value))
+          Try(write($value)).toOption
           """
     )
   }
@@ -33,8 +34,9 @@ object UpickleJsonSerializerMacro {
 
     c.Expr[Option[T]](
       q"""
+          import scala.util.Try
           import upickle.default._
-          Option(read[$deserializeType]($json))
+          Try(read[$deserializeType]($json)).toOption
           """
     )
   }


### PR DESCRIPTION
The change will respond method not found error if server could not find the method and if ID was attached.

On client side, ```Future[RESULT]``` returned by the client API method will fail with ```JsonRpcException``` with the responded ```JsonRpcErrorResponse```.

Tests are passing, but some refactoring needs to occur before merging both on test and prod code.