### PR TITLE
Fix read and write method names conflicting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea
+*.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.12.1
+  - 2.12.2
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,20 @@ scala:
 jdk:
   - oraclejdk8
 
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+
 before_script:
+  - wget -N http://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip
+  - sudo apt-get install libnss3
+  - sudo apt-get --only-upgrade install google-chrome-stable
+  - sudo cp chromedriver /usr/local/bin/.
+  - sudo chmod +x /usr/local/bin/chromedriver
   - "export DISPLAY=:99"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: scala
 
 scala:

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ JSON-RPC defines a specification of RPC in JSON format. This means that you can 
 Using scala-json-rpc, your server and client can communicate over statically typed interfaces like below:
 
 ```scala
-trait LoggerApi {
+trait LoggerAPI {
   def log(message: String): Unit
 }
 
 case class Foo(id: String)
 
-trait FooRepositoryApi {
+trait FooRepositoryAPI {
   def add(foo: Foo): Future[Unit]
   def remove(foo: Foo): Future[Unit]
   def getAll(): Future[Set[Foo]]
@@ -43,11 +43,11 @@ trait FooRepositoryApi {
 ### Server
 
 ```scala
-class LoggerApiImpl extends LoggerApi {
+class LoggerAPIImpl extends LoggerAPI {
   override def log(message: String): Unit = println(message)
 }
 
-class FooRepositoryApiImpl extends FooRepositoryApi {
+class FooRepositoryAPIImpl extends FooRepositoryAPI {
   var foos: Set[Foo] = Set()
 
   override def add(foo: Foo): Future[Unit] = this.synchronized {
@@ -60,15 +60,15 @@ class FooRepositoryApiImpl extends FooRepositoryApi {
     Future() // Acknowledge
   }
 
-  override def getAll(): Future[Set[Foo]] = {
-    Future(foos)
+  override def getAll(): Future[Set[Foo]] = Future {
+    foos
   }
 }
 
 val jsonSerializer = // ...
 val server = jsonRpcServer(jsonSerializer)
-server.bindApi[LoggerApi](new LoggerApiImpl)
-server.bindApi[FooRepositoryApi](new FooRepositoryApiImpl)
+server.bindAPI[LoggerAPI](new LoggerAPIImpl)
+server.bindAPI[FooRepositoryAPI](new FooRepositoryAPIImpl)
 
 def onRequestJsonReceived(requestJson: String): Unit = {
   server.receive(requestJson).onComplete {
@@ -85,17 +85,17 @@ val jsonSerializer = // ...
 val jsonSender = // ...
 val client = JsonRpcClient(jsonSerializer, jsonSender)
 
-val loggerApi = client.createApi[LoggerApi]
-val fooRepositoryApi = client.createApi[FooRepositoryApi]
+val loggerAPI = client.createAPI[LoggerAPI]
+val fooRepositoryAPI = client.createAPI[FooRepositoryAPI]
 
-loggerApi.log("Hello, World!")
+loggerAPI.log("Hello, World!")
 
-fooRepositoryApi.add(Foo("A"))
-fooRepositoryApi.add(Foo("B"))
+fooRepositoryAPI.add(Foo("A"))
+fooRepositoryAPI.add(Foo("B"))
 
-fooRepositoryApi.remove(Foo("A"))
+fooRepositoryAPI.remove(Foo("A"))
 
-fooRepositoryApi.getAll().onComplete {
+fooRepositoryAPI.getAll().onComplete {
   case Success(foos: Set[Foo]) => println(s"Received all the foos: $foos")
   case _ =>
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-crossScalaVersions := Seq("2.12.1")
+crossScalaVersions := Seq("2.12.2")
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
@@ -13,7 +13,7 @@ val commonSettings = Seq(
   organization := "io.github.shogowada",
   name := "scala-json-rpc",
   version := "0.6.0",
-  scalaVersion := "2.12.1",
+  scalaVersion := "2.12.2",
   logBuffered in Test := false,
   licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT")),
   homepage := Some(url("https://github.com/shogowada/scala-json-rpc")),
@@ -101,14 +101,14 @@ lazy val exampleJvmCommonSettings = Seq(
     "org.eclipse.jetty" % "jetty-webapp" % JettyVersion,
     "org.scalatra" %% "scalatra" % "2.5.+",
 
-    "org.seleniumhq.selenium" % "selenium-java" % "2.+" % "it",
+    "org.seleniumhq.selenium" % "selenium-java" % "[3.4.0,4.0.0[" % "it",
     "org.scalatest" %% "scalatest" % "3.+" % "it"
   )
 )
 
 lazy val exampleJsCommonSettings = Seq(
   libraryDependencies ++= Seq(
-    "io.github.shogowada" %%% "scalajs-reactjs" % "0.5.+",
+    "io.github.shogowada" %%% "scalajs-reactjs" % "0.11.+",
     "org.scala-js" %%% "scalajs-dom" % "0.9.+"
   )
 )

--- a/examples/e2e-web-socket/README.md
+++ b/examples/e2e-web-socket/README.md
@@ -42,7 +42,7 @@ object TodoEventTypes {
 
 case class TodoEvent(todo: Todo, eventType: String)
 
-trait TodoRepositoryApi {
+trait TodoRepositoryAPI {
   def add(description: String): Future[Todo]
 
   def remove(id: String): Future[Unit]
@@ -68,7 +68,7 @@ object Main extends JSApp {
     val mountNode = dom.document.getElementById("mount-node")
     ReactDOM.render(
       new TodoListView(
-        serverAndClient.createApi[TodoRepositoryApi]
+        serverAndClient.createAPI[TodoRepositoryAPI]
       )(TodoListView.Props()),
       mountNode
     )
@@ -137,7 +137,7 @@ object Main extends JSApp {
 Here is our API implementation:
 
 ```scala
-class TodoRepositoryApiImpl extends TodoRepositoryApi {
+class TodoRepositoryAPIImpl extends TodoRepositoryAPI {
 
   var todos: Seq[Todo] = Seq()
   var observersById: Map[String, DisposableFunction1[TodoEvent, Future[Unit]]] = Map()
@@ -198,7 +198,7 @@ Here is our WebSocket implementation:
 ```scala
 object JsonRpcModule {
 
-  lazy val todoRepositoryApi = new TodoRepositoryApiImpl
+  lazy val todoRepositoryAPI = new TodoRepositoryAPIImpl
 
   lazy val jsonSerializer = UpickleJsonSerializer()
 
@@ -207,7 +207,7 @@ object JsonRpcModule {
     val client = JsonRpcClient(jsonSerializer, jsonSender)
     val serverAndClient = JsonRpcServerAndClient(server, client)
 
-    serverAndClient.bindApi[TodoRepositoryApi](todoRepositoryApi)
+    serverAndClient.bindAPI[TodoRepositoryAPI](todoRepositoryAPI)
 
     serverAndClient
   }

--- a/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/Main.scala
+++ b/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/Main.scala
@@ -8,6 +8,7 @@ import io.github.shogowada.scala.jsonrpc.client.JsonRpcClient
 import io.github.shogowada.scala.jsonrpc.serializers.UpickleJsonSerializer
 import io.github.shogowada.scala.jsonrpc.server.JsonRpcServer
 import io.github.shogowada.scalajs.reactjs.ReactDOM
+import io.github.shogowada.scalajs.reactjs.VirtualDOM._
 import org.scalajs.dom
 import org.scalajs.dom.WebSocket
 
@@ -23,9 +24,7 @@ object Main extends JSApp {
 
     val mountNode = dom.document.getElementById("mount-node")
     ReactDOM.render(
-      new TodoListView(
-        serverAndClient.createApi[TodoRepositoryApi]
-      )(TodoListView.Props()),
+      <((new TodoListView(serverAndClient.createApi[TodoRepositoryApi])) ()).empty,
       mountNode
     )
   }

--- a/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/Main.scala
+++ b/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/Main.scala
@@ -24,7 +24,7 @@ object Main extends JSApp {
 
     val mountNode = dom.document.getElementById("mount-node")
     ReactDOM.render(
-      <((new TodoListView(serverAndClient.createApi[TodoRepositoryApi])) ()).empty,
+      <((new TodoListView(serverAndClient.createAPI[TodoRepositoryAPI])) ()).empty,
       mountNode
     )
   }

--- a/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/TodoListView.scala
+++ b/examples/e2e-web-socket/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/TodoListView.scala
@@ -67,7 +67,7 @@ object TodoListView {
 }
 
 class TodoListView(
-    todoRepositoryApi: TodoRepositoryApi
+    todoRepositoryAPI: TodoRepositoryAPI
 ) {
 
   import TodoListView._
@@ -77,7 +77,7 @@ class TodoListView(
   private lazy val reactClass = React.createClass[Unit, State](
     getInitialState = (self) => State(ready = false, Seq()),
     componentDidMount = (self) => {
-      val futureObserverId = todoRepositoryApi.register(onTodoEvent(self, _))
+      val futureObserverId = todoRepositoryAPI.register(onTodoEvent(self, _))
 
       futureObserverId.onComplete {
         case Success(_) => self.setState(_.copy(ready = true))
@@ -88,7 +88,7 @@ class TodoListView(
     },
     componentWillUnmount = (self) => {
       promisedObserverId.future.foreach(observerId => {
-        todoRepositoryApi.unregister(observerId)
+        todoRepositoryAPI.unregister(observerId)
       })
     },
     render = (self) =>
@@ -128,10 +128,10 @@ class TodoListView(
   }
 
   private val onAddTodo = (description: String) => {
-    todoRepositoryApi.add(description)
+    todoRepositoryAPI.add(description)
   }: Unit
 
   private val onRemoveTodo = (todo: Todo) => {
-    todoRepositoryApi.remove(todo.id)
+    todoRepositoryAPI.remove(todo.id)
   }: Unit
 }

--- a/examples/e2e-web-socket/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/integrationtest/TodoListTest.scala
+++ b/examples/e2e-web-socket/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/integrationtest/TodoListTest.scala
@@ -26,6 +26,7 @@ class TodoListTest extends path.FreeSpec
     "when I add TODO item" - {
       val newTodoDescription = "Say hello"
 
+      waitFor(ExpectedConditions.visibilityOfElementLocated(By.id(ElementIds.NewTodoDescription)))
       textField(id(ElementIds.NewTodoDescription)).value = newTodoDescription
       clickOn(id(ElementIds.AddTodo))
 

--- a/examples/e2e-web-socket/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/integrationtest/TodoListTest.scala
+++ b/examples/e2e-web-socket/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/integrationtest/TodoListTest.scala
@@ -4,11 +4,11 @@ import io.github.shogowada.scala.jsonrpc.example.e2e.websocket.ElementIds
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.openqa.selenium.{By, WebDriver}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.selenium.Firefox
+import org.scalatest.selenium.{Chrome, Firefox}
 import org.scalatest.{Matchers, path}
 
 class TodoListTest extends path.FreeSpec
-    with Firefox
+    with Chrome
     with Eventually
     with Matchers {
 

--- a/examples/e2e-web-socket/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/JsonRpcModule.scala
+++ b/examples/e2e-web-socket/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/JsonRpcModule.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object JsonRpcModule {
 
-  lazy val todoRepositoryApi = new TodoRepositoryApiImpl
+  lazy val todoRepositoryAPI = new TodoRepositoryAPIImpl
 
   lazy val jsonSerializer = UpickleJsonSerializer()
 
@@ -19,7 +19,7 @@ object JsonRpcModule {
     val client = JsonRpcClient(jsonSerializer, jsonSender)
     val serverAndClient = JsonRpcServerAndClient(server, client)
 
-    serverAndClient.bindApi[TodoRepositoryApi](todoRepositoryApi)
+    serverAndClient.bindAPI[TodoRepositoryAPI](todoRepositoryAPI)
 
     serverAndClient
   }

--- a/examples/e2e-web-socket/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/TodoRepositoryAPIImpl.scala
+++ b/examples/e2e-web-socket/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/TodoRepositoryAPIImpl.scala
@@ -7,7 +7,7 @@ import io.github.shogowada.scala.jsonrpc.DisposableFunction1
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class TodoRepositoryApiImpl extends TodoRepositoryApi {
+class TodoRepositoryAPIImpl extends TodoRepositoryAPI {
 
   var todos: Seq[Todo] = Seq()
   var observersById: Map[String, DisposableFunction1[TodoEvent, Future[Unit]]] = Map()

--- a/examples/e2e-web-socket/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/API.scala
+++ b/examples/e2e-web-socket/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/websocket/API.scala
@@ -15,7 +15,7 @@ object TodoEventTypes {
 
 case class TodoEvent(todo: Todo, eventType: String)
 
-trait TodoRepositoryApi {
+trait TodoRepositoryAPI {
   def add(description: String): Future[Todo]
 
   def remove(id: String): Future[Unit]

--- a/examples/e2e/README.md
+++ b/examples/e2e/README.md
@@ -9,16 +9,16 @@ You can see the complete code under this directory, but we have documented some 
 We define the following 3 JSON-RPC APIs.
 
 ```scala
-trait CalculatorApi {
+trait CalculatorAPI {
   def add(lhs: Int, rhs: Int): Future[Int]
   def subtract(lhs: Int, rhs: Int): Future[Int]
 }
 
-trait EchoApi {
+trait EchoAPI {
   def echo(message: String): Future[String]
 }
 
-trait LoggerApi {
+trait LoggerAPI {
   def log(message: String): Unit
 }
 ```
@@ -28,7 +28,7 @@ trait LoggerApi {
 We implement the APIs on server side like below.
 
 ```scala
-class CalculatorApiImpl extends CalculatorApi {
+class CalculatorAPIImpl extends CalculatorAPI {
   override def add(lhs: Int, rhs: Int): Future[Int] = {
     Future(lhs + rhs)
   }
@@ -37,13 +37,13 @@ class CalculatorApiImpl extends CalculatorApi {
   }
 }
 
-class EchoApiImpl extends EchoApi {
+class EchoAPIImpl extends EchoAPI {
   override def echo(message: String): Future[String] = {
     Future(message) // It just returns the message as is
   }
 }
 
-class LoggerApiImpl extends LoggerApi {
+class LoggerAPIImpl extends LoggerAPI {
   override def log(message: String): Unit = {
     println(message) // It logs the message
   }
@@ -56,9 +56,9 @@ We build JSON-RPC server using those API implementations.
 object JsonRpcModule {
   lazy val jsonRpcServer: JsonRpcServer[UpickleJsonSerializer] = {
     val server = JsonRpcServer(UpickleJsonSerializer())
-    server.bindApi[CalculatorApi](new CalculatorApiImpl)
-    server.bindApi[EchoApi](new EchoApiImpl)
-    server.bindApi[LoggerApi](new LoggerApiImpl)
+    server.bindAPI[CalculatorAPI](new CalculatorAPIImpl)
+    server.bindAPI[EchoAPI](new EchoAPIImpl)
+    server.bindAPI[LoggerAPI](new LoggerAPIImpl)
     server
   }
 }
@@ -110,32 +110,32 @@ val client = JsonRpcClient(UpickleJsonSerializer(), jsonSender)
 Once the client is built, we can use it to create and use the APIs like below.
 
 ```scala
-val calculatorApi = client.createApi[CalculatorApi]
-val echoApi = client.createApi[EchoApi]
-val loggerApi = client.createApi[LoggerApi]
+val calculatorAPI = client.createAPI[CalculatorAPI]
+val echoAPI = client.createAPI[EchoAPI]
+val loggerAPI = client.createAPI[LoggerAPI]
 
-loggerApi.log("This is the beginning of my example.")
+loggerAPI.log("This is the beginning of my example.")
 
-calculatorApi.add(1, 2).onComplete {
+calculatorAPI.add(1, 2).onComplete {
   case Success(result) => println(s"1 + 2 = $result")
   case _ =>
 }
 
-calculatorApi.subtract(1, 2).onComplete {
+calculatorAPI.subtract(1, 2).onComplete {
   case Success(result) => println(s"1 - 2 = $result")
   case _ =>
 }
 
-echoApi.echo("Hello, World!").onComplete {
+echoAPI.echo("Hello, World!").onComplete {
   case Success(result) => println(s"""You said "$result"""")
   case _ =>
 }
 
-loggerApi.log("This is the end of my example.")
+loggerAPI.log("This is the end of my example.")
 ```
 
 When you run this, you will see that:
 
-- calculations via ```calculatorApi``` is operated on server and returned to client.
-- messages sent via ```echoApi``` reaches to server and returned to client as is.
-- messages sent via ```loggerApi``` is logged on server.
+- calculations via ```calculatorAPI``` is operated on server and returned to client.
+- messages sent via ```echoAPI``` reaches to server and returned to client as is.
+- messages sent via ```loggerAPI``` is logged on server.

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Calculator.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Calculator.scala
@@ -14,7 +14,7 @@ object Calculator {
   type Self = React.Self[Unit, State]
 }
 
-class Calculator(calculatorApi: CalculatorApi) {
+class Calculator(calculatorAPI: CalculatorAPI) {
 
   import Calculator._
 
@@ -77,14 +77,14 @@ class Calculator(calculatorApi: CalculatorApi) {
       val lhs = self.state.lhs
       val rhs = self.state.rhs
 
-      calculatorApi.add(lhs, rhs).onComplete {
+      calculatorAPI.add(lhs, rhs).onComplete {
         case Success(added) if lhs == self.state.lhs && rhs == self.state.rhs => {
           self.setState(_.copy(added = Some(added)))
         }
         case _ =>
       }
 
-      calculatorApi.subtract(lhs, rhs).onComplete {
+      calculatorAPI.subtract(lhs, rhs).onComplete {
         case Success(subtracted) if lhs == self.state.lhs && rhs == self.state.rhs => {
           self.setState(_.copy(subtracted = Some(subtracted)))
         }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Calculator.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Calculator.scala
@@ -1,93 +1,94 @@
 package io.github.shogowada.scala.jsonrpc.example.e2e
 
+import io.github.shogowada.scalajs.reactjs.React
 import io.github.shogowada.scalajs.reactjs.VirtualDOM._
-import io.github.shogowada.scalajs.reactjs.classes.specs.ReactClassSpec
-import io.github.shogowada.scalajs.reactjs.elements.ReactHTMLInputElement
-import io.github.shogowada.scalajs.reactjs.events.SyntheticEvent
+import io.github.shogowada.scalajs.reactjs.events.{FormSyntheticEvent, SyntheticEvent}
+import org.scalajs.dom.raw.HTMLInputElement
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Success
 
 object Calculator {
-
-  case class Props()
-
   case class State(lhs: Int, rhs: Int, added: Option[Int], subtracted: Option[Int])
 
+  type Self = React.Self[Unit, State]
 }
 
-class Calculator(calculatorApi: CalculatorApi) extends ReactClassSpec {
-  type Props = Calculator.Props
-  type State = Calculator.State
+class Calculator(calculatorApi: CalculatorApi) {
 
-  private var lhsElement: ReactHTMLInputElement = _
-  private var rhsElement: ReactHTMLInputElement = _
+  import Calculator._
 
-  override def getInitialState() = {
-    Calculator.State(0, 0, None, None)
-  }
+  def apply() = reactClass
 
-  override def render() = {
-    <.div()(
-      <.h2()("Calculator"),
-      <.form(^.onSubmit := onSubmit)(
-        <.input(
-          ^.id := ElementIds.CalculatorLhs,
-          ^.ref := ((element: ReactHTMLInputElement) => {
-            lhsElement = element
-          }),
-          ^.onChange := onChange,
-          ^.value := state.lhs
-        )(),
-        <.input(
-          ^.id := ElementIds.CalculatorRhs,
-          ^.ref := ((element: ReactHTMLInputElement) => {
-            rhsElement = element
-          }),
-          ^.onChange := onChange,
-          ^.value := state.rhs
-        )(),
-        <.button(
-          ^.id := ElementIds.CalculatorCalculate,
-          ^.`type` := "submit"
-        )("Calculate")
-      ),
-      <.div(^.id := ElementIds.CalculatorAdded)(
-        s"${state.lhs} + ${state.rhs} = ${state.added.getOrElse("?")}"
-      ),
-      <.div(^.id := ElementIds.CalculatorSubtracted)(
-        s"${state.lhs} - ${state.rhs} = ${state.subtracted.getOrElse("?")}"
-      )
-    ).asReactElement
-  }
+  private lazy val reactClass = React.createClass[Unit, State](
+    getInitialState = (self) => Calculator.State(0, 0, None, None),
+    render = (self) =>
+      <.div()(
+        <.h2()("Calculator"),
+        <.form(^.onSubmit := onSubmit(self))(
+          <.input(
+            ^.id := ElementIds.CalculatorLhs,
+            ^.onChange := onLhsChange(self),
+            ^.value := self.state.lhs
+          )(),
+          <.input(
+            ^.id := ElementIds.CalculatorRhs,
+            ^.onChange := onRhsChange(self),
+            ^.value := self.state.rhs
+          )(),
+          <.button(
+            ^.id := ElementIds.CalculatorCalculate,
+            ^.`type` := "submit"
+          )("Calculate")
+        ),
+        <.div(^.id := ElementIds.CalculatorAdded)(
+          s"${self.state.lhs} + ${self.state.rhs} = ${self.state.added.getOrElse("?")}"
+        ),
+        <.div(^.id := ElementIds.CalculatorSubtracted)(
+          s"${self.state.lhs} - ${self.state.rhs} = ${self.state.subtracted.getOrElse("?")}"
+        )
+      ).asReactElement
+  )
 
-  private val onChange = () => {
-    setState(state.copy(
-      lhs = lhsElement.value.toInt,
-      rhs = rhsElement.value.toInt,
-      added = None,
-      subtracted = None
-    ))
-  }
-
-  private val onSubmit = (event: SyntheticEvent) => {
-    event.preventDefault()
-
-    val lhs = state.lhs
-    val rhs = state.rhs
-
-    calculatorApi.add(lhs, rhs).onComplete {
-      case Success(added) if lhs == state.lhs && rhs == state.rhs => {
-        setState(_.copy(added = Some(added)))
-      }
-      case _ =>
+  private def onLhsChange(self: Self) =
+    (event: FormSyntheticEvent[HTMLInputElement]) => {
+      val value = event.target.value
+      self.setState(_.copy(
+        lhs = value.toInt,
+        added = None,
+        subtracted = None
+      ))
     }
 
-    calculatorApi.subtract(lhs, rhs).onComplete {
-      case Success(subtracted) if lhs == state.lhs && rhs == state.rhs => {
-        setState(_.copy(subtracted = Some(subtracted)))
-      }
-      case _ =>
+  private def onRhsChange(self: Self) =
+    (event: FormSyntheticEvent[HTMLInputElement]) => {
+      val value = event.target.value
+      self.setState(_.copy(
+        rhs = value.toInt,
+        added = None,
+        subtracted = None
+      ))
     }
-  }
+
+  private def onSubmit(self: Self) =
+    (event: SyntheticEvent) => {
+      event.preventDefault()
+
+      val lhs = self.state.lhs
+      val rhs = self.state.rhs
+
+      calculatorApi.add(lhs, rhs).onComplete {
+        case Success(added) if lhs == self.state.lhs && rhs == self.state.rhs => {
+          self.setState(_.copy(added = Some(added)))
+        }
+        case _ =>
+      }
+
+      calculatorApi.subtract(lhs, rhs).onComplete {
+        case Success(subtracted) if lhs == self.state.lhs && rhs == self.state.rhs => {
+          self.setState(_.copy(subtracted = Some(subtracted)))
+        }
+        case _ =>
+      }
+    }
 }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Echo.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Echo.scala
@@ -1,54 +1,53 @@
 package io.github.shogowada.scala.jsonrpc.example.e2e
 
+import io.github.shogowada.scalajs.reactjs.React
 import io.github.shogowada.scalajs.reactjs.VirtualDOM._
-import io.github.shogowada.scalajs.reactjs.classes.specs.ReactClassSpec
-import io.github.shogowada.scalajs.reactjs.events.InputFormSyntheticEvent
+import io.github.shogowada.scalajs.reactjs.events.FormSyntheticEvent
+import org.scalajs.dom.raw.HTMLInputElement
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Success
 
 object Echo {
-
-  case class Props()
-
   case class State(text: String, echoedText: Option[String])
 
+  type Self = React.Self[Unit, State]
 }
 
-class Echo(echoApi: EchoApi) extends ReactClassSpec {
+class Echo(echoApi: EchoApi) {
 
-  type Props = Echo.Props
-  type State = Echo.State
+  import Echo._
 
-  override def getInitialState() = {
-    Echo.State(text = "", echoedText = Some(""))
-  }
+  def apply() = reactClass
 
-  override def render() = {
-    <.div()(
-      <.h2()("Echo"),
-      <.label(^.`for` := ElementIds.EchoText)("I say:"),
-      <.input(
-        ^.id := ElementIds.EchoText,
-        ^.value := state.text,
-        ^.onChange := onChange
-      )(),
-      <.label(^.`for` := ElementIds.EchoEchoedText)("Server says:"),
-      <.span(^.id := ElementIds.EchoEchoedText)(state.echoedText.getOrElse(""))
-    ).asReactElement
-  }
+  private lazy val reactClass = React.createClass[Unit, State](
+    getInitialState = (self) => State(text = "", echoedText = Some("")),
+    render = (self) =>
+      <.div()(
+        <.h2()("Echo"),
+        <.label(^.`for` := ElementIds.EchoText)("I say:"),
+        <.input(
+          ^.id := ElementIds.EchoText,
+          ^.value := self.state.text,
+          ^.onChange := onChange(self)
+        )(),
+        <.label(^.`for` := ElementIds.EchoEchoedText)("Server says:"),
+        <.span(^.id := ElementIds.EchoEchoedText)(self.state.echoedText.getOrElse(""))
+      ).asReactElement
+  )
 
-  private val onChange = (event: InputFormSyntheticEvent) => {
-    val text = event.target.value
+  private def onChange(self: Self) =
+    (event: FormSyntheticEvent[HTMLInputElement]) => {
+      val text = event.target.value
 
-    setState(_.copy(
-      text = text,
-      echoedText = None
-    ))
+      self.setState(_.copy(
+        text = text,
+        echoedText = None
+      ))
 
-    echoApi.echo(text).onComplete {
-      case Success(echoedText) if state.text == text => setState(_.copy(echoedText = Some(echoedText)))
-      case _ =>
+      echoApi.echo(text).onComplete {
+        case Success(echoedText) if self.state.text == text => self.setState(_.copy(echoedText = Some(echoedText)))
+        case _ =>
+      }
     }
-  }
 }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Echo.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Echo.scala
@@ -14,7 +14,7 @@ object Echo {
   type Self = React.Self[Unit, State]
 }
 
-class Echo(echoApi: EchoApi) {
+class Echo(echoAPI: EchoAPI) {
 
   import Echo._
 
@@ -45,7 +45,7 @@ class Echo(echoApi: EchoApi) {
         echoedText = None
       ))
 
-      echoApi.echo(text).onComplete {
+      echoAPI.echo(text).onComplete {
         case Success(echoedText) if self.state.text == text => self.setState(_.copy(echoedText = Some(echoedText)))
         case _ =>
       }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Logger.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Logger.scala
@@ -1,76 +1,78 @@
 package io.github.shogowada.scala.jsonrpc.example.e2e
 
+import io.github.shogowada.scalajs.reactjs.React
 import io.github.shogowada.scalajs.reactjs.VirtualDOM._
-import io.github.shogowada.scalajs.reactjs.classes.specs.ReactClassSpec
-import io.github.shogowada.scalajs.reactjs.events.{InputFormSyntheticEvent, SyntheticEvent}
+import io.github.shogowada.scalajs.reactjs.events.{FormSyntheticEvent, SyntheticEvent}
+import org.scalajs.dom.raw.HTMLInputElement
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Success
 
 object Logger {
-
-  case class Props()
-
   case class State(log: String, logs: Seq[String])
 
+  type Self = React.Self[Unit, State]
 }
 
-class Logger(loggerApi: LoggerApi) extends ReactClassSpec {
-  type Props = Logger.Props
-  type State = Logger.State
+class Logger(loggerApi: LoggerApi) {
 
-  override def getInitialState() = {
-    Logger.State("", Seq())
-  }
+  import Logger._
 
-  override def render() = {
-    <.div()(
-      <.h2()("Logger"),
-      <.form(^.onSubmit := onLog)(
-        <.input(
-          ^.id := ElementIds.LoggerLogText,
-          ^.value := state.log,
-          ^.onChange := onChange
-        )(),
-        <.button(
-          ^.id := ElementIds.LoggerLog,
-          ^.`type` := "submit"
-        )("Log")
-      ),
-      <.form(^.onSubmit := onGetLogs)(
-        <.button(
-          ^.id := ElementIds.LoggerGetLogs,
-          ^.`type` := "submit"
-        )("Get Logs")
-      ),
-      <.div(^.id := ElementIds.LoggerLogs)(
-        state.logs.map(log => {
-          <.div()(log)
-        })
-      )
-    ).asReactElement
-  }
+  def apply() = reactClass
 
-  private val onChange = (event: InputFormSyntheticEvent) => {
-    val log = event.target.value
+  private lazy val reactClass = React.createClass[Unit, State](
+    getInitialState = (self) => State("", Seq()),
+    render = (self) =>
+      <.div()(
+        <.h2()("Logger"),
+        <.form(^.onSubmit := onLog(self))(
+          <.input(
+            ^.id := ElementIds.LoggerLogText,
+            ^.value := self.state.log,
+            ^.onChange := onChange(self)
+          )(),
+          <.button(
+            ^.id := ElementIds.LoggerLog,
+            ^.`type` := "submit"
+          )("Log")
+        ),
+        <.form(^.onSubmit := onGetLogs(self))(
+          <.button(
+            ^.id := ElementIds.LoggerGetLogs,
+            ^.`type` := "submit"
+          )("Get Logs")
+        ),
+        <.div(^.id := ElementIds.LoggerLogs)(
+          self.state.logs.map(log => {
+            <.div()(log)
+          })
+        )
+      ).asReactElement
+  )
 
-    setState(_.copy(log = log))
-  }
+  private def onChange(self: Self) =
+    (event: FormSyntheticEvent[HTMLInputElement]) => {
+      val log = event.target.value
 
-  private val onLog = (event: SyntheticEvent) => {
-    event.preventDefault()
-
-    loggerApi.log(state.log)
-
-    setState(_.copy(log = ""))
-  }
-
-  private val onGetLogs = (event: SyntheticEvent) => {
-    event.preventDefault()
-
-    loggerApi.getAllLogs().onComplete {
-      case Success(logs) => setState(_.copy(logs = logs))
-      case _ =>
+      self.setState(_.copy(log = log))
     }
-  }
+
+  private def onLog(self: Self) =
+    (event: SyntheticEvent) => {
+      event.preventDefault()
+
+      loggerApi.log(self.state.log)
+
+      self.setState(_.copy(log = ""))
+    }
+
+  private def onGetLogs(self: Self) =
+    (event: SyntheticEvent) => {
+      event.preventDefault()
+
+      loggerApi.getAllLogs().onComplete {
+        case Success(logs) => self.setState(_.copy(logs = logs))
+        case _ =>
+      }
+    }
 }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Logger.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Logger.scala
@@ -14,7 +14,7 @@ object Logger {
   type Self = React.Self[Unit, State]
 }
 
-class Logger(loggerApi: LoggerApi) {
+class Logger(loggerAPI: LoggerAPI) {
 
   import Logger._
 
@@ -61,7 +61,7 @@ class Logger(loggerApi: LoggerApi) {
     (event: SyntheticEvent) => {
       event.preventDefault()
 
-      loggerApi.log(self.state.log)
+      loggerAPI.log(self.state.log)
 
       self.setState(_.copy(log = ""))
     }
@@ -70,7 +70,7 @@ class Logger(loggerApi: LoggerApi) {
     (event: SyntheticEvent) => {
       event.preventDefault()
 
-      loggerApi.getAllLogs().onComplete {
+      loggerAPI.getAllLogs().onComplete {
         case Success(logs) => self.setState(_.copy(logs = logs))
         case _ =>
       }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Main.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Main.scala
@@ -4,7 +4,7 @@ import io.github.shogowada.scala.jsonrpc.client.JsonRpcClient
 import io.github.shogowada.scala.jsonrpc.serializers.UpickleJsonSerializer
 import io.github.shogowada.scalajs.reactjs.ReactDOM
 import io.github.shogowada.scalajs.reactjs.VirtualDOM._
-import io.github.shogowada.scalajs.reactjs.classes.specs.StatelessReactClassSpec
+import io.github.shogowada.scalajs.reactjs.elements.ReactElement
 import org.scalajs.dom
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -15,17 +15,13 @@ class App(
     calculatorApi: CalculatorApi,
     echoApi: EchoApi,
     loggerApi: LoggerApi
-) extends StatelessReactClassSpec {
-
-  case class Props()
-
-  override def render() = {
+) {
+  def apply(): ReactElement =
     <.div()(
-      new Calculator(calculatorApi)(Calculator.Props()),
-      new Echo(echoApi)(Echo.Props()),
-      new Logger(loggerApi)(Logger.Props())
+      <((new Calculator(calculatorApi)) ()).empty,
+      <((new Echo(echoApi)) ()).empty,
+      <((new Logger(loggerApi)) ()).empty
     )
-  }
 }
 
 object Main extends JSApp {
@@ -51,6 +47,6 @@ object Main extends JSApp {
     val loggerApi = client.createApi[LoggerApi]
 
     val mountNode = dom.document.getElementById("mount-node")
-    ReactDOM.render(new App(calculatorApi, echoApi, loggerApi), mountNode)
+    ReactDOM.render((new App(calculatorApi, echoApi, loggerApi)) (), mountNode)
   }
 }

--- a/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Main.scala
+++ b/examples/e2e/js/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/Main.scala
@@ -12,15 +12,15 @@ import scala.concurrent.Future
 import scala.scalajs.js.JSApp
 
 class App(
-    calculatorApi: CalculatorApi,
-    echoApi: EchoApi,
-    loggerApi: LoggerApi
+    calculatorAPI: CalculatorAPI,
+    echoAPI: EchoAPI,
+    loggerAPI: LoggerAPI
 ) {
   def apply(): ReactElement =
     <.div()(
-      <((new Calculator(calculatorApi)) ()).empty,
-      <((new Echo(echoApi)) ()).empty,
-      <((new Logger(loggerApi)) ()).empty
+      <((new Calculator(calculatorAPI)) ()).empty,
+      <((new Echo(echoAPI)) ()).empty,
+      <((new Logger(loggerAPI)) ()).empty
     )
 }
 
@@ -42,11 +42,11 @@ object Main extends JSApp {
 
     val client = JsonRpcClient(UpickleJsonSerializer(), jsonSender)
 
-    val calculatorApi = client.createApi[CalculatorApi]
-    val echoApi = client.createApi[EchoApi]
-    val loggerApi = client.createApi[LoggerApi]
+    val calculatorAPI = client.createAPI[CalculatorAPI]
+    val echoAPI = client.createAPI[EchoAPI]
+    val loggerAPI = client.createAPI[LoggerAPI]
 
     val mountNode = dom.document.getElementById("mount-node")
-    ReactDOM.render((new App(calculatorApi, echoApi, loggerApi)) (), mountNode)
+    ReactDOM.render((new App(calculatorAPI, echoAPI, loggerAPI)) (), mountNode)
   }
 }

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/CalculatorTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/CalculatorTest.scala
@@ -2,13 +2,13 @@ package io.github.shogowada.scala.jsonrpc.example.e2e.integrationtest
 
 import io.github.shogowada.scala.jsonrpc.example.e2e.ElementIds
 import org.scalatest.concurrent.Eventually
-import org.scalatest.selenium.Firefox
+import org.scalatest.selenium.{Chrome, Firefox}
 import org.scalatest.{Matchers, path}
 
 class CalculatorTest extends path.FreeSpec
     with Eventually
     with Matchers
-    with Firefox {
+    with Chrome {
 
   "given I am on the calculator page" - {
     go to Target.url

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/CalculatorTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/CalculatorTest.scala
@@ -41,5 +41,5 @@ class CalculatorTest extends path.FreeSpec
     }
   }
 
-  close()
+  quit()
 }

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/EchoTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/EchoTest.scala
@@ -26,5 +26,5 @@ class EchoTest extends path.FreeSpec
     }
   }
 
-  close()
+  quit()
 }

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/EchoTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/EchoTest.scala
@@ -2,13 +2,13 @@ package io.github.shogowada.scala.jsonrpc.example.e2e.integrationtest
 
 import io.github.shogowada.scala.jsonrpc.example.e2e.ElementIds
 import org.scalatest.concurrent.Eventually
-import org.scalatest.selenium.Firefox
+import org.scalatest.selenium.{Chrome, Firefox}
 import org.scalatest.{Matchers, path}
 
 class EchoTest extends path.FreeSpec
     with Matchers
     with Eventually
-    with Firefox {
+    with Chrome {
 
   "given I am on the echo page" - {
     go to Target.url

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/LoggerTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/LoggerTest.scala
@@ -31,5 +31,5 @@ class LoggerTest extends path.FreeSpec
     }
   }
 
-  close()
+  quit()
 }

--- a/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/LoggerTest.scala
+++ b/examples/e2e/jvm/src/it/scala/io/github/shogowada/scala/jsonrpc/example/e2e/integrationtest/LoggerTest.scala
@@ -2,13 +2,13 @@ package io.github.shogowada.scala.jsonrpc.example.e2e.integrationtest
 
 import io.github.shogowada.scala.jsonrpc.example.e2e.ElementIds
 import org.scalatest.concurrent.Eventually
-import org.scalatest.selenium.Firefox
+import org.scalatest.selenium.{Chrome, Firefox}
 import org.scalatest.{Matchers, path}
 
 class LoggerTest extends path.FreeSpec
     with Matchers
     with Eventually
-    with Firefox {
+    with Chrome {
 
   "given I am on logger page" - {
     go to Target.url

--- a/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/ApiImpl.scala
+++ b/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/ApiImpl.scala
@@ -3,7 +3,7 @@ package io.github.shogowada.scala.jsonrpc.example.e2e
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class CalculatorApiImpl extends CalculatorApi {
+class CalculatorAPIImpl extends CalculatorAPI {
   override def add(lhs: Int, rhs: Int): Future[Int] = {
     Future(lhs + rhs)
   }
@@ -13,13 +13,13 @@ class CalculatorApiImpl extends CalculatorApi {
   }
 }
 
-class EchoApiImpl extends EchoApi {
+class EchoAPIImpl extends EchoAPI {
   override def echo(message: String): Future[String] = {
     Future(message) // It just returns the message as is
   }
 }
 
-class LoggerApiImpl extends LoggerApi {
+class LoggerAPIImpl extends LoggerAPI {
   var logs: Seq[String] = Seq()
 
   override def log(message: String): Unit = this.synchronized {

--- a/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/JsonRpcModule.scala
+++ b/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/JsonRpcModule.scala
@@ -6,13 +6,13 @@ import io.github.shogowada.scala.jsonrpc.server.JsonRpcServer
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object JsonRpcModule {
-  lazy val loggerApi: LoggerAPI = new LoggerAPIImpl
+  lazy val loggerAPI: LoggerAPI = new LoggerAPIImpl
 
   lazy val jsonRpcServer: JsonRpcServer[UpickleJsonSerializer] = {
     val server = JsonRpcServer(UpickleJsonSerializer())
     server.bindAPI[CalculatorAPI](new CalculatorAPIImpl)
     server.bindAPI[EchoAPI](new EchoAPIImpl)
-    server.bindAPI[LoggerAPI](loggerApi)
+    server.bindAPI[LoggerAPI](loggerAPI)
     server
   }
 }

--- a/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/JsonRpcModule.scala
+++ b/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/JsonRpcModule.scala
@@ -6,13 +6,13 @@ import io.github.shogowada.scala.jsonrpc.server.JsonRpcServer
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object JsonRpcModule {
-  lazy val loggerApi: LoggerApi = new LoggerApiImpl
+  lazy val loggerApi: LoggerAPI = new LoggerAPIImpl
 
   lazy val jsonRpcServer: JsonRpcServer[UpickleJsonSerializer] = {
     val server = JsonRpcServer(UpickleJsonSerializer())
-    server.bindApi[CalculatorApi](new CalculatorApiImpl)
-    server.bindApi[EchoApi](new EchoApiImpl)
-    server.bindApi[LoggerApi](loggerApi)
+    server.bindAPI[CalculatorAPI](new CalculatorAPIImpl)
+    server.bindAPI[EchoAPI](new EchoAPIImpl)
+    server.bindAPI[LoggerAPI](loggerApi)
     server
   }
 }

--- a/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/LogServlet.scala
+++ b/examples/e2e/jvm/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/LogServlet.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.Duration
 
 class LogServlet extends ScalatraServlet {
   get("/") {
-    val futureResult = JsonRpcModule.loggerApi.getAllLogs()
+    val futureResult = JsonRpcModule.loggerAPI.getAllLogs()
         .map(logs => Ok(logs))
     Await.result(futureResult, Duration(1, TimeUnit.MINUTES))
   }

--- a/examples/e2e/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/API.scala
+++ b/examples/e2e/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/example/e2e/API.scala
@@ -2,17 +2,17 @@ package io.github.shogowada.scala.jsonrpc.example.e2e
 
 import scala.concurrent.Future
 
-trait CalculatorApi {
+trait CalculatorAPI {
   def add(lhs: Int, rhs: Int): Future[Int]
 
   def subtract(lhs: Int, rhs: Int): Future[Int]
 }
 
-trait EchoApi {
+trait EchoAPI {
   def echo(message: String): Future[String]
 }
 
-trait LoggerApi {
+trait LoggerAPI {
   def log(message: String): Unit
 
   def getAllLogs(): Future[Seq[String]]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.3")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.14")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.5.0")
 addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.5.0")
 

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClient.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClient.scala
@@ -36,11 +36,11 @@ object JsonRpcServerAndClientMacro {
     val (serverAndClientDefinition, serverAndClient) = macroUtils.prefixDefinitionAndReference
     val server = q"$serverAndClient.server"
     val client = q"$serverAndClient.client"
-    val bindApi = JsonRpcServerMacro.bindApiImpl[c.type, API](c)(server, Some(client), api)
+    val bindAPI = JsonRpcServerMacro.bindAPIImpl[c.type, API](c)(server, Some(client), api)
     c.Expr[Unit](
       q"""
           $serverAndClientDefinition
-          $bindApi
+          $bindAPI
           """
     )
   }
@@ -51,11 +51,11 @@ object JsonRpcServerAndClientMacro {
     val (serverAndClientDefinition, serverAndClient) = macroUtils.prefixDefinitionAndReference
     val server = q"$serverAndClient.server"
     val client = q"$serverAndClient.client"
-    val createApi = JsonRpcClientMacro.createApiImpl[c.type, API](c)(client, Some(server))
+    val createAPI = JsonRpcClientMacro.createAPIImpl[c.type, API](c)(client, Some(server))
     c.Expr[API](
       q"""
           $serverAndClientDefinition
-          $createApi
+          $createAPI
           """
     )
   }

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClient.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClient.scala
@@ -9,28 +9,28 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-class JsonRpcServerAndClient[JSON_SERIALIZER <: JsonSerializer](
-    val server: JsonRpcServer[JSON_SERIALIZER],
-    val client: JsonRpcClient[JSON_SERIALIZER]
+class JsonRpcServerAndClient[JsonSerializerInUse <: JsonSerializer](
+    val server: JsonRpcServer[JsonSerializerInUse],
+    val client: JsonRpcClient[JsonSerializerInUse]
 ) {
   def send(json: String): Future[Option[String]] = client.send(json)
 
-  def bindApi[API](api: API): Unit = macro JsonRpcServerAndClientMacro.bindApi[API]
+  def bindAPI[API](api: API): Unit = macro JsonRpcServerAndClientMacro.bindAPI[API]
 
-  def createApi[API]: API = macro JsonRpcServerAndClientMacro.createApi[API]
+  def createAPI[API]: API = macro JsonRpcServerAndClientMacro.createAPI[API]
 
   def receiveAndSend(json: String): Future[Unit] = macro JsonRpcServerAndClientMacro.receiveAndSend
 }
 
 object JsonRpcServerAndClient {
-  def apply[JSON_SERIALIZER <: JsonSerializer](
-      server: JsonRpcServer[JSON_SERIALIZER],
-      client: JsonRpcClient[JSON_SERIALIZER]
+  def apply[JsonSerializerInUse <: JsonSerializer](
+      server: JsonRpcServer[JsonSerializerInUse],
+      client: JsonRpcClient[JsonSerializerInUse]
   ) = new JsonRpcServerAndClient(server, client)
 }
 
 object JsonRpcServerAndClientMacro {
-  def bindApi[API: c.WeakTypeTag](c: blackbox.Context)(api: c.Expr[API]): c.Expr[Unit] = {
+  def bindAPI[API: c.WeakTypeTag](c: blackbox.Context)(api: c.Expr[API]): c.Expr[Unit] = {
     import c.universe._
     val macroUtils = JsonRpcMacroUtils[c.type](c)
     val (serverAndClientDefinition, serverAndClient) = macroUtils.prefixDefinitionAndReference
@@ -45,7 +45,7 @@ object JsonRpcServerAndClientMacro {
     )
   }
 
-  def createApi[API: c.WeakTypeTag](c: blackbox.Context): c.Expr[API] = {
+  def createAPI[API: c.WeakTypeTag](c: blackbox.Context): c.Expr[API] = {
     import c.universe._
     val macroUtils = JsonRpcMacroUtils[c.type](c)
     val (serverAndClientDefinition, serverAndClient) = macroUtils.prefixDefinitionAndReference

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClient.scala
@@ -42,7 +42,7 @@ object JsonRpcClientMacro {
     import c.universe._
     val macroUtils = JsonRpcMacroUtils[c.type](c)
     val (clientDefinition, client) = macroUtils.prefixDefinitionAndReference
-    val api = createApiImpl[c.type, API](c)(client, None)
+    val api = createAPIImpl[c.type, API](c)(client, None)
     c.Expr[API](
       q"""
           $clientDefinition
@@ -51,7 +51,7 @@ object JsonRpcClientMacro {
     )
   }
 
-  def createApiImpl[Context <: blackbox.Context, API: c.WeakTypeTag](c: Context)(
+  def createAPIImpl[Context <: blackbox.Context, API: c.WeakTypeTag](c: Context)(
       client: c.Tree,
       maybeServer: Option[c.Tree]
   ): c.Expr[API] = {
@@ -73,7 +73,7 @@ object JsonRpcClientMacro {
   ): Iterable[c.Tree] = {
     import c.universe._
     val apiType: Type = weakTypeOf[API]
-    JsonRpcMacroUtils[c.type](c).getJsonRpcApiMethods(apiType)
+    JsonRpcMacroUtils[c.type](c).getJsonRpcAPIMethods(apiType)
         .map((apiMethod: MethodSymbol) => createMemberFunction[c.type](c)(client, maybeServer, apiMethod))
   }
 

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcRequestJsonHandlerFactoryMacro.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcRequestJsonHandlerFactoryMacro.scala
@@ -23,7 +23,7 @@ class JsonRpcRequestJsonHandlerFactoryMacro[CONTEXT <: blackbox.Context](val c: 
       returnType: c.Type
   )
 
-  def createFromApiMethod[API](
+  def createFromAPIMethod[API](
       server: c.Tree,
       maybeClient: Option[c.Tree],
       api: c.Expr[API],

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServer.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServer.scala
@@ -37,7 +37,7 @@ object JsonRpcServerMacro {
     import c.universe._
     val macroUtils = JsonRpcMacroUtils[c.type](c)
     val (serverDefinition, server) = macroUtils.prefixDefinitionAndReference
-    val bind = bindApiImpl[c.type, API](c)(server, None, api)
+    val bind = bindAPIImpl[c.type, API](c)(server, None, api)
     c.Expr[Unit](
       q"""
           $serverDefinition
@@ -46,7 +46,7 @@ object JsonRpcServerMacro {
     )
   }
 
-  def bindApiImpl[Context <: blackbox.Context, API: c.WeakTypeTag](c: Context)(
+  def bindAPIImpl[Context <: blackbox.Context, API: c.WeakTypeTag](c: Context)(
       server: c.Tree,
       maybeClient: Option[c.Tree],
       api: c.Expr[API]
@@ -58,7 +58,7 @@ object JsonRpcServerMacro {
     val requestJsonHandlerRepository = macroUtils.getRequestJsonHandlerRepository(server)
 
     val apiType: Type = weakTypeOf[API]
-    val methodNameToRequestJsonHandlerList = JsonRpcMacroUtils[c.type](c).getJsonRpcApiMethods(apiType)
+    val methodNameToRequestJsonHandlerList = JsonRpcMacroUtils[c.type](c).getJsonRpcAPIMethods(apiType)
         .map((apiMember: MethodSymbol) => createMethodNameToRequestJsonHandler[c.type, API](c)(server, maybeClient, api, apiMember))
 
     c.Expr[Unit](
@@ -82,7 +82,7 @@ object JsonRpcServerMacro {
     val requestJsonHandlerFactoryMacro = new JsonRpcRequestJsonHandlerFactoryMacro[c.type](c)
 
     val methodName = macroUtils.getJsonRpcMethodName(method)
-    val handler = requestJsonHandlerFactoryMacro.createFromApiMethod[API](server, maybeClient, api, method)
+    val handler = requestJsonHandlerFactoryMacro.createFromAPIMethod[API](server, maybeClient, api, method)
 
     c.Expr[(String, RequestJsonHandler)](q"""$methodName -> $handler""")
   }

--- a/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/utils/JsonRpcMacroUtils.scala
+++ b/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/utils/JsonRpcMacroUtils.scala
@@ -43,7 +43,7 @@ class JsonRpcMacroUtils[CONTEXT <: blackbox.Context](val c: CONTEXT) {
     // used at the point of macro expansion will always be used for the macro.
     // For example, if you have the following code
     //
-    // server.bindApi[Api]
+    // server.bindAPI[API]
     // server = null
     //
     // then the API bound will break because its c.prefix.tree is now changed to null.
@@ -54,7 +54,7 @@ class JsonRpcMacroUtils[CONTEXT <: blackbox.Context](val c: CONTEXT) {
     )
   }
 
-  def getJsonRpcApiMethods(apiType: Type): Iterable[MethodSymbol] = {
+  def getJsonRpcAPIMethods(apiType: Type): Iterable[MethodSymbol] = {
     apiType.decls
         .filter((apiMember: Symbol) => isJsonRpcMethod(apiMember))
         .map((apiMember: Symbol) => apiMember.asMethod)

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClientTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/JsonRpcServerAndClientTest.scala
@@ -32,9 +32,9 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
     }
 
     describe("and I have an API that takes function as parameter") {
-      class AnApiThatTakesFunction extends TwoServersAndClients {
+      class AnAPIThatTakesFunction extends TwoServersAndClients {
 
-        trait Api {
+        trait API {
           def foo(
               requestFunction: DisposableFunction1[String, Future[String]],
               notificationFunction: DisposableFunction1[String, Unit]
@@ -51,7 +51,7 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
         val promisedNotificationValue1: Promise[String] = Promise()
         val promisedNotificationValue2: Promise[String] = Promise()
 
-        class ApiImpl extends Api {
+        class APIImpl extends API {
           var requestFunction: DisposableFunction1[String, Future[String]] = _
           var notificationFunction: DisposableFunction1[String, Unit] = _
 
@@ -70,10 +70,10 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
           }
         }
 
-        val apiImpl = new ApiImpl
-        serverAndClient1.bindApi[Api](apiImpl)
+        val apiImpl = new APIImpl
+        serverAndClient1.bindAPI[API](apiImpl)
 
-        val apiClient = serverAndClient2.createApi[Api]
+        val apiClient = serverAndClient2.createAPI[API]
 
         val requestFunctionImpl: (String) => Future[String] = (value: String) => {
           Future(value)
@@ -88,12 +88,12 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
       }
 
       it("then it should create a client API") {
-        val fixture = new AnApiThatTakesFunction
+        val fixture = new AnAPIThatTakesFunction
         fixture.apiClient should not be null
       }
 
       describe("when I call the method") {
-        class CallTheMethod extends AnApiThatTakesFunction {
+        class CallTheMethod extends AnAPIThatTakesFunction {
           apiClient.foo(requestFunctionImpl, notificationFunctionImpl)
         }
 
@@ -164,22 +164,22 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
     }
 
     describe("given I have an API that returns a function") {
-      class ApiThatReturnsFunction extends TwoServersAndClients {
+      class APIThatReturnsFunction extends TwoServersAndClients {
 
-        trait Api {
+        trait API {
           def foo: Future[DisposableFunction0[Future[String]]]
         }
 
-        class ApiImpl extends Api {
+        class APIImpl extends API {
           override def foo = Future(() => Future("foo"))
         }
 
-        serverAndClient1.bindApi[Api](new ApiImpl)
-        val client = serverAndClient2.createApi[Api]
+        serverAndClient1.bindAPI[API](new APIImpl)
+        val client = serverAndClient2.createAPI[API]
       }
 
       describe("when I call the function") {
-        class CallTheFunction extends ApiThatReturnsFunction {
+        class CallTheFunction extends APIThatReturnsFunction {
           val futureFunction: Future[DisposableFunction0[Future[String]]] = client.foo
           val futureFoo: Future[String] = futureFunction.flatMap(function => function())
         }
@@ -220,17 +220,17 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
     }
 
     describe("given I have an API that takes the same function type in 2 places") {
-      class ClientApiThatTakes2Functions extends TwoServersAndClients {
+      class ClientAPIThatTakes2Functions extends TwoServersAndClients {
         val promisedFoo1Function: Promise[DisposableFunction0[Unit]] = Promise()
         val promisedFoo2Function: Promise[DisposableFunction0[Unit]] = Promise()
 
-        trait Api {
+        trait API {
           def foo1(bar: DisposableFunction0[Unit]): Unit
 
           def foo2(bar: DisposableFunction0[Unit]): Unit
         }
 
-        class ApiImpl extends Api {
+        class APIImpl extends API {
           override def foo1(bar: DisposableFunction0[Unit]): Unit = {
             promisedFoo1Function.success(bar)
           }
@@ -240,12 +240,12 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
           }
         }
 
-        serverAndClient1.bindApi[Api](new ApiImpl)
-        val client = serverAndClient2.createApi[Api]
+        serverAndClient1.bindAPI[API](new APIImpl)
+        val client = serverAndClient2.createAPI[API]
       }
 
       describe("when I call them both with the same function") {
-        class CallThemBothWithTheSameFunction extends ClientApiThatTakes2Functions {
+        class CallThemBothWithTheSameFunction extends ClientAPIThatTakes2Functions {
           val function: () => Unit = () => {}
           client.foo1(function)
           client.foo2(function)
@@ -261,7 +261,7 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
       }
 
       describe("when I call them both with different functions") {
-        class CallThemBothWithDifferentFunctions extends ClientApiThatTakes2Functions {
+        class CallThemBothWithDifferentFunctions extends ClientAPIThatTakes2Functions {
           client.foo1(() => {})
           client.foo2(() => {})
         }
@@ -279,18 +279,18 @@ class JsonRpcServerAndClientTest extends AsyncFunSpec
     describe("and I changed the reference to servers and clients") {
       class IChangedTheReference extends TwoServersAndClients {
 
-        trait Api {
+        trait API {
           def foo(): Future[String]
         }
 
-        class ApiImpl extends Api {
+        class APIImpl extends API {
           override def foo(): Future[String] = {
             Future("foo")
           }
         }
 
-        serverAndClient1.bindApi[Api](new ApiImpl)
-        val api = serverAndClient2.createApi[Api]
+        serverAndClient1.bindAPI[API](new APIImpl)
+        val api = serverAndClient2.createAPI[API]
 
         serverAndClient1 = null
         serverAndClient2 = null

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClientTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClientTest.scala
@@ -19,7 +19,7 @@ class JsonRpcClientTest extends AsyncFunSpec
     }
 
     describe("when I create a client API") {
-      val api = client.createApi[Api]
+      val api = client.createAPI[Api]
 
       it("then it should be an instance of the API") {
         api.isInstanceOf[Api] should equal(true)

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClientTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/client/JsonRpcClientTest.scala
@@ -14,15 +14,15 @@ class JsonRpcClientTest extends AsyncFunSpec
   val client = JsonRpcClient(UpickleJsonSerializer(), (json: String) => jsonSender(json))
 
   describe("given I have an API") {
-    trait Api {
+    trait API {
       def foo(bar: String, baz: Int): Future[String]
     }
 
     describe("when I create a client API") {
-      val api = client.createAPI[Api]
+      val api = client.createAPI[API]
 
       it("then it should be an instance of the API") {
-        api.isInstanceOf[Api] should equal(true)
+        api.isInstanceOf[API] should equal(true)
       }
 
       describe("and it fails to send the JSON") {

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServerTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServerTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{Assertion, AsyncFunSpec, Matchers}
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
 
-trait FakeApi {
+trait FakeAPI {
   def foo(bar: String, baz: Int): Future[String]
 
   @api.JsonRpcMethod(name = "bar")
@@ -17,7 +17,7 @@ trait FakeApi {
   def notify(message: String): Unit
 }
 
-class FakeApiImpl extends FakeApi {
+class FakeAPIImpl extends FakeAPI {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -40,11 +40,11 @@ class JsonRpcServerTest extends AsyncFunSpec
   override implicit def executionContext = ExecutionContext.Implicits.global
 
   describe("given I have an API bound") {
-    val api = new FakeApiImpl
+    val api = new FakeAPIImpl
 
     val jsonSerializer = UpickleJsonSerializer()
     val target = JsonRpcServer(jsonSerializer)
-    target.bindAPI[FakeApi](api)
+    target.bindAPI[FakeAPI](api)
 
     def responseShouldEqual[T]
     (
@@ -76,7 +76,7 @@ class JsonRpcServerTest extends AsyncFunSpec
       val request: JsonRpcRequest[(String, Int)] = JsonRpcRequest(
         jsonrpc = Constants.JsonRpc,
         id = requestId,
-        method = classOf[FakeApi].getName + ".foo",
+        method = classOf[FakeAPI].getName + ".foo",
         params = ("bar", 1)
       )
       val requestJson: String = jsonSerializer.serialize(request).get
@@ -125,7 +125,7 @@ class JsonRpcServerTest extends AsyncFunSpec
       val message = "Hello, World!"
       val notification = JsonRpcNotification[Tuple1[String]](
         jsonrpc = Constants.JsonRpc,
-        method = classOf[FakeApi].getName + ".notify",
+        method = classOf[FakeAPI].getName + ".notify",
         params = Tuple1(message)
       )
       val notificationJson = jsonSerializer.serialize(notification).get
@@ -213,7 +213,7 @@ class JsonRpcServerTest extends AsyncFunSpec
       val request: JsonRpcRequest[Tuple1[String]] = JsonRpcRequest(
         jsonrpc = Constants.JsonRpc,
         id = id,
-        method = classOf[FakeApi].getName + ".foo",
+        method = classOf[FakeAPI].getName + ".foo",
         params = Tuple1("bar")
       )
       val requestJson = jsonSerializer.serialize(request).get

--- a/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServerTest.scala
+++ b/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/server/JsonRpcServerTest.scala
@@ -44,7 +44,7 @@ class JsonRpcServerTest extends AsyncFunSpec
 
     val jsonSerializer = UpickleJsonSerializer()
     val target = JsonRpcServer(jsonSerializer)
-    target.bindApi[FakeApi](api)
+    target.bindAPI[FakeApi](api)
 
     def responseShouldEqual[T]
     (

--- a/tutorials/basic.md
+++ b/tutorials/basic.md
@@ -21,7 +21,7 @@ For example, if you want to have a repository of `Foo` and make it available rem
 ```scala
 case class Foo(id: String)
 
-trait FooRepositoryApi {
+trait FooRepositoryAPI {
   def add(foo: Foo): Unit
   def remove(foo: Foo): Unit
   def getAll(): Future[Set[Foo]]
@@ -38,7 +38,7 @@ It needs to return `Future[_]` because RPC happens remotely, meaning:
 If your method returns `Unit`, it will be JSON-RPC notification, meaning you don't get any response including errors. If you don't need anything returned but still want to know if the RPC succeeded, you can let it return `Future[Unit]`.
 
 ```scala
-trait FooRepositoryApi {
+trait FooRepositoryAPI {
   def add(foo: Foo): Future[Unit]
   def remove(foo: Foo): Future[Unit]
   def getAll(): Future[Set[Foo]]
@@ -96,10 +96,10 @@ val jsonSender: (String) => Future[Option[String]] = (json: String) => {
 }
 val jsonRpcClient = JsonRpcClient(jsonSerializer, jsonSender)
 
-val fooRepositoryApi = jsonRpcClient.createApi[FooRepositoryApi]
+val fooRepositoryAPI = jsonRpcClient.createAPI[FooRepositoryAPI]
 
 val fooA = Foo("A")
-fooRepositoryApi.add(fooA).onComplete {
+fooRepositoryAPI.add(fooA).onComplete {
   case Success(_) => println(s"Successfully added $fooA to the repository")
   case _ => println(s"Failed to add $fooA to the repository")
 }
@@ -189,13 +189,13 @@ We will cover those in the following sections, but here is a piece of code to gi
 val jsonSerializer = new MyJsonSerializer()
 val jsonRpcServer = JsonRpcServer(jsonSerializer)
 
-class FooRepositoryApiImpl extends FooRepositoryApi {
-  // Implement FooRepositoryApi
+class FooRepositoryAPIImpl extends FooRepositoryAPI {
+  // Implement FooRepositoryAPI
   // ...
 }
 
-val fooRepositoryApi = new FooRepositoryApiImpl
-jsonRpcServer.bindApi[FooRepositoryApi](fooRepositoryApi)
+val fooRepositoryAPI = new FooRepositoryAPIImpl
+jsonRpcServer.bindAPI[FooRepositoryAPI](fooRepositoryAPI)
 
 jsonRpcServer.receive(String).onComplete {
   case Success(Some(responseJson)) => {
@@ -259,16 +259,16 @@ val jsonRpcClient = JsonRpcClient(/* ... */)
 val jsonRpcServerAndClient = JsonRpcServerAndClient(jsonRpcServer, jsonRpcClient)
 ```
 
-Just as how it looks like, you think of `JsonRpcServerAndClient` as `JsonRpcServer` and `JsonRpcClient` combined. You can still bind your API implementation using `bindApi[API](api: API)` method:
+Just as how it looks like, you think of `JsonRpcServerAndClient` as `JsonRpcServer` and `JsonRpcClient` combined. You can still bind your API implementation using `bindAPI[API](api: API)` method:
 
 ```scala
-jsonRpcServerAndClient.bindApi[FooRepositoryApi](new FooRepositoryApiImpl)
+jsonRpcServerAndClient.bindAPI[FooRepositoryAPI](new FooRepositoryAPIImpl)
 ```
 
-or use `createApi[API]` to create an API client:
+or use `createAPI[API]` to create an API client:
 
 ```scala
-val fooRepositoryApi = jsonRpcServerAndClient.createApi[FooRepositoryApi]
+val fooRepositoryAPI = jsonRpcServerAndClient.createAPI[FooRepositoryAPI]
 ```
 
 You can receive request JSON and send response JSON by using `receive`. The method can also take care of sending response JSON because it already has access to your `JsonSender` given to `JsonRpcClient`.

--- a/tutorials/custom-json-rpc-method-name.md
+++ b/tutorials/custom-json-rpc-method-name.md
@@ -5,12 +5,12 @@ By default, method name is full name of the method. For example, if you have an 
 ```scala
 package io.github.shogowada
 
-trait Api {
+trait API {
   def foo: Unit
 }
 ```
 
-Then JSON-RPC method name for the API method ```foo``` will be ```io.github.shogowada.Api.foo```. If you are using this library only to achieve RMI between your Scala components, this is convenient to guarantee uniqueness of the method names.
+Then JSON-RPC method name for the API method ```foo``` will be ```io.github.shogowada.API.foo```. If you are using this library only to achieve RMI between your Scala components, this is convenient to guarantee uniqueness of the method names.
 
 But sometimes you want to define custom method names so that it integrates well with other components written with different technologies.
 
@@ -21,7 +21,7 @@ package io.github.shogowada
 
 import io.github.shogowada.scala.jsonrpc.api
 
-trait Api {
+trait API {
   @api.JsonRpcMethod(name = "foo")
   def foo: Unit
 }

--- a/tutorials/passing-function-as-parameter-or-return-value-or-both.md
+++ b/tutorials/passing-function-as-parameter-or-return-value-or-both.md
@@ -44,35 +44,35 @@ val jsonRpcServerAndClient = JsonRpcServerAndClient(jsonRpcServer, jsonRpcClient
 ## Create API that takes DisposableFunction as parameter or return value or both
 
 ```scala
-trait EchoApi {
+trait EchoAPI {
   def echo(message: String, callback: DisposableFunction1[String, Unit]): Unit
 }
 
-trait UuidSubjectApi {
+trait UuidSubjectAPI {
   def register(observer: DisposableFunction1[String, Future[Unit]]): Unit
   def unregister(observer: DisposableFunction1[String, Future[Unit]]): Unit
 }
 // Or, you might want to return an unregister function
-trait UuidSubjectApi {
+trait UuidSubjectAPI {
   def register(observer: DisposableFunction1[String, Future[Unit]]): Future[DisposableFunction0[Unit]]
 }
 ```
 
 Internally, `JsonRpcFuncion` is just another JSON-RPC client, so just like an API method, **you need to return either `Unit` or `Future`**.
 
-The `UuidSubjectApi.unregister` works because **if the same function reference is passed from client, it will be the same function reference on server too**.
+The `UuidSubjectAPI.unregister` works because **if the same function reference is passed from client, it will be the same function reference on server too**.
 
 ## Implement server
 
 ```scala
-class EchoApiImpl extends EchoApi {
+class EchoAPIImpl extends EchoAPI {
   override def echo(message: String, callback: DisposableFunction1[String, Unit]): Unit = {
     callback(message)
     callback.dispose() // Dispose the function when you no longer use it.
   }
 }
 
-class UuidSubjectApiImpl extends UuidSubjectApi {
+class UuidSubjectAPIImpl extends UuidSubjectAPI {
   var observers: Set[DisposableFunction1[String, Future[Unit]]] = Set()
 
   // ... Set timer so that we will invoke the following method periodically.
@@ -96,8 +96,8 @@ class UuidSubjectApiImpl extends UuidSubjectApi {
 }
 
 val serverAndClient = JsonRpcServerAndClient(/* ... */)
-serverAndClient.bindApi[EchoApi](new EchoApiImpl)
-serverAndClient.bindApi[UuidSubjectApi](new UuidSubjectApiImpl)
+serverAndClient.bindAPI[EchoAPI](new EchoAPIImpl)
+serverAndClient.bindAPI[UuidSubjectAPI](new UuidSubjectAPIImpl)
 ```
 
 You can use the `DisposableFunction` just like regular function except **you need to explicitly dispose the function when you no longer use it**. This is so that both server and client can dispose relative mappings.
@@ -107,8 +107,8 @@ You can use the `DisposableFunction` just like regular function except **you nee
 ```scala
 val serverAndClient = JsonRpcServerAndClient(/* ... */)
 
-val echoApi = serverAndClient.createApi[Api]
-echoApi.echo("Hello, World!", (message: String) => {
+val echoAPI = serverAndClient.createAPI[API]
+echoAPI.echo("Hello, World!", (message: String) => {
   println(s"Server echoed: $message")
 })
 
@@ -116,9 +116,9 @@ val uuidObserver: (String) => Future[Unit] = (uuid: String) => {
   println(s"Notified UUID: $uuid")
   Future() // Let server know it was successful
 }
-val uuidSubjectApi = serverAndClient.createApi[UuidSubjectApi]
-uuidSubjectApi.register(uuidObserver)
-uuidSubjectApi.unregister(uuidObserver)
+val uuidSubjectAPI = serverAndClient.createAPI[UuidSubjectAPI]
+uuidSubjectAPI.register(uuidObserver)
+uuidSubjectAPI.unregister(uuidObserver)
 ```
 
 On client side, also, you can use the parameter just like regular functions because `FunctionN` types are implicitly converted to `DisposableFunctionN` types. If you want to explicitly create `DisposableFunction`, you can do so by using its factory method like `DisposableFunction((message: String) => println(message))` or `DisposableFunction(uuidObserver)`.
@@ -128,7 +128,7 @@ On client side, also, you can use the parameter just like regular functions beca
 To illustrate how it's wroking, let's take the following API as an example.
 
 ```scala
-trait FooApi {
+trait FooAPI {
   def foo(bar: DisposableFunction1[String, Future[String]]): Future[String]
 }
 ```
@@ -139,7 +139,7 @@ When you invoke an `foo` function from client, passing your function as `bar`, i
 {
   "jsonrpc": "2.0",
   "id": "<request ID>",
-  "method": "FooApi.foo",
+  "method": "FooAPI.foo",
   "params": ["<method.name.for.the.bar.function>"]
 }
 ```

--- a/upickle-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/UpickleJsonSerializer.scala
+++ b/upickle-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/UpickleJsonSerializer.scala
@@ -52,9 +52,7 @@ object UpickleJsonSerializerMacro {
 
     c.Expr[Option[String]](
       q"""
-          import scala.util.Try
-          import io.github.shogowada.scala.jsonrpc.serializers.JsonRpcPickler._
-          Try(write($value)).toOption
+          scala.util.Try(io.github.shogowada.scala.jsonrpc.serializers.JsonRpcPickler.write($value)).toOption
           """
     )
   }
@@ -66,9 +64,7 @@ object UpickleJsonSerializerMacro {
 
     c.Expr[Option[T]](
       q"""
-          import scala.util.Try
-          import io.github.shogowada.scala.jsonrpc.serializers.JsonRpcPickler._
-          Try(read[$deserializeType]($json)).toOption
+          scala.util.Try(io.github.shogowada.scala.jsonrpc.serializers.JsonRpcPickler.read[$deserializeType]($json)).toOption
           """
     )
   }


### PR DESCRIPTION
- Fix `read` method name was conflicting when `UpickleJsonSerializer` is in use
- Fix `write` method name was conflicting when `UpickleJsonSerializer` is in use

Breaking changes:

- Rename `bindApi` to `bindAPI`
- Rename `createApi` to `createAPI`
