### PR TITLE
Roshttp json rpc client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.sbt-hydra-history
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,21 @@ lazy val core = (crossProject in file("."))
 lazy val jvm = core.jvm
 lazy val js = core.js
 
+lazy val roshttpJSONRPCClient = (crossProject in file("roshttp-json-rpc-client"))
+    .disablePlugins(AssemblyPlugin)
+    .settings(commonSettings: _*)
+    .settings(
+      name += "-roshttp-json-rpc-client",
+      libraryDependencies ++= Seq(
+        "fr.hmil" %%% "roshttp" % "2.0.2"
+      ),
+      publishArtifact := true
+    )
+    .dependsOn(core)
+
+lazy val roshttpJSONRPCClientJvm = roshttpJSONRPCClient.jvm
+lazy val roshttpJSONRPCClientJs = roshttpJSONRPCClient.js
+
 lazy val jsonSerializer = (crossProject in file("json-serializer"))
     .disablePlugins(AssemblyPlugin)
     .settings(commonSettings: _*)

--- a/roshttp-json-rpc-client/README.md
+++ b/roshttp-json-rpc-client/README.md
@@ -1,0 +1,23 @@
+# roshttp-json-rpc-client
+
+|Platform|SBT|Scala Version|Scala JS Version|
+|---|---|---|---|
+|JVM|```"io.github.shogowada" %% "scala-json-rpc-roshttp-json-rpc-client" % "0.9.1"```|2.12||
+|JS|```"io.github.shogowada" %%% "scala-json-rpc-roshttp-json-rpc-client" % "0.9.1"```|2.12|0.6.15+|
+
+You can use roshttp-json-rpc-client to use [RösHTTP](https://github.com/hmil/RosHTTP) as your ```JSONRPCClient``` (serializer sold separately).
+
+```scala
+val jsonSerializer = ??? // serializer sold separately
+
+val server = JSONRPCServer(jsonSerializer)
+
+import monix.execution.Scheduler.Implicits.global
+
+val client = RosHTTPJSONRPCClient(
+    jsonSerializer,
+    "http://json.rpc/endpoint",
+    "Optional" → "additional",
+    "Http" → "headers"
+)
+```

--- a/roshttp-json-rpc-client/src/main/scala/io/github/shogowada/scala/jsonrpc/client/RosHTTPJSONRPCClient.scala
+++ b/roshttp-json-rpc-client/src/main/scala/io/github/shogowada/scala/jsonrpc/client/RosHTTPJSONRPCClient.scala
@@ -1,0 +1,43 @@
+package io.github.shogowada.scala.jsonrpc.client
+
+import monix.execution.Scheduler
+import fr.hmil.roshttp.HttpRequest
+import fr.hmil.roshttp.body.ByteBufferBody
+import io.github.shogowada.scala.jsonrpc.Types.JSONSender
+
+class RosHTTPJSONRPCClient[JSONSerializerInUse <: JSONSerializer](
+  jsonSerializer: JSONSerializerInUse,
+  jsonRPCEndpoint: String,
+  httpHeaders: Seq[(String, String)]
+)(implicit scheduler: Scheduler)
+    extends JSONRPCClient[JSONSerializerInUse](
+  jsonSerializer,
+  jsonSender,
+  scheduler
+)
+{
+  val jsonSender: JSONSender = { json ⇒
+    HttpRequest(jsonRPCEndpoint)
+      .withHeaders(httpHeaders)
+      .post(
+        ByteBufferBody(
+          data = java.nio.ByteBuffer.wrap(json.getBytes),
+          contentType = "application/json; charset=utf-8"
+        )
+      )
+  }
+}
+
+object RosHTTPJSONRPCClient {
+  def apply(
+    jsonSerializer: JSONSerializer,
+    jsonRPCEndpoint: String,
+    httpHeaders: (String, String)*
+  ): RosHTTPJSONRPCClient = {
+    new RosHTTPJSONRPCClient(
+      jsonSerializer,
+      jsonRPCEndpoint,
+      httpHeaders
+    )
+  }
+}


### PR DESCRIPTION
similar to the `upickle-json-serializer` project, thought it'd be nice to have a convenience/quick-start implementation that cross compiles for `jvm` and `js` for the `JSONRPCClient` as well