### PR TITLE
Replaced Auto derivation with Custom Circe codecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 language: scala
 
 scala:
-  - 2.12.2
+  - 2.12.9
 
 jdk:
   - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ def onResponseJSONReceived(responseJSON: String): Unit = {
 
 |Platform|SBT|Scala Version|Scala JS Version|
 |---|---|---|---|
-|JVM|```"io.github.shogowada" %% "scala-json-rpc" % "0.9.3"```|2.12||
-|JS|```"io.github.shogowada" %%% "scala-json-rpc" % "0.9.3"```|2.12|0.6.17+|
+|JVM|```"io.github.shogowada" %% "scala-json-rpc" % "1.0.0"```|2.12||
+|JS|```"io.github.shogowada" %%% "scala-json-rpc" % "1.0.0"```|2.12|0.6.28+|
 
 scala-json-rpc has **no external dependency**, so it should fit into any of your Scala JVM & JS applications.
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ val commonSettings = Seq(
 )
 
 val Version = new {
-  val circe = "0.8.0"
+  val circe = "0.9.1"
 }
 
 lazy val core = (crossProject in file("."))
@@ -96,12 +96,12 @@ lazy val circeJSONSerializer = (crossProject in file("circe-json-serializer"))
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         "io.circe" %%% "circe-parser" % Version.circe,
-        "io.circe" %%% "circe-generic" % Version.circe,
+        "io.circe" %%% "circe-core" % Version.circe,
         "org.scalatest" %%% "scalatest" % "3.+" % "test"
       ),
       publishArtifact := true
     )
-    .dependsOn(jsonSerializer)
+    .dependsOn(core, jsonSerializer)
 
 lazy val circeJSONSerializerJvm = circeJSONSerializer.jvm
 lazy val circeJSONSerializerJs = circeJSONSerializer.js

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-crossScalaVersions := Seq("2.12.2")
+crossScalaVersions := Seq("2.12.9")
 
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
@@ -12,8 +12,8 @@ publishArtifact := false
 val commonSettings = Seq(
   organization := "io.github.shogowada",
   name := "scala-json-rpc",
-  version := "0.9.3",
-  scalaVersion := "2.12.2",
+  version := "1.0.0",
+  scalaVersion := "2.12.9",
   logBuffered in Test := false,
   licenses := Seq("MIT" -> url("https://opensource.org/licenses/MIT")),
   homepage := Some(url("https://github.com/shogowada/scala-json-rpc")),
@@ -40,7 +40,7 @@ val commonSettings = Seq(
 )
 
 val Version = new {
-  val circe = "0.9.1"
+  val circe = "0.11.0"
 }
 
 lazy val core = (crossProject in file("."))
@@ -50,7 +50,8 @@ lazy val core = (crossProject in file("."))
       libraryDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
 
-        "org.scalatest" %%% "scalatest" % "3.+" % Test
+        "org.scalatest" %%% "scalatest" % "3.+" % Test,
+        "org.scalacheck" %% "scalacheck" % "1.14+" % Test
       ),
       publishArtifact := true
     )
@@ -97,7 +98,9 @@ lazy val circeJSONSerializer = (crossProject in file("circe-json-serializer"))
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
         "io.circe" %%% "circe-parser" % Version.circe,
         "io.circe" %%% "circe-core" % Version.circe,
-        "org.scalatest" %%% "scalatest" % "3.+" % "test"
+        "io.circe" %%% "circe-generic" % Version.circe % "test",
+        "org.scalatest" %%% "scalatest" % "3.+" % "test",
+        "org.scalacheck" %% "scalacheck" % "1.14+" % "test"
       ),
       publishArtifact := true
     )
@@ -124,7 +127,8 @@ lazy val exampleJvmCommonSettings = Seq(
     "org.scalatra" %% "scalatra" % "2.5.+",
 
     "org.seleniumhq.selenium" % "selenium-java" % "[3.4.0,4.0.0[" % "it",
-    "org.scalatest" %% "scalatest" % "3.+" % "it"
+    "org.scalatest" %% "scalatest" % "3.+" % "it",
+    "org.scalacheck" %% "scalacheck" % "1.14+" % "it"
   )
 )
 

--- a/circe-json-serializer/README.md
+++ b/circe-json-serializer/README.md
@@ -2,8 +2,8 @@
 
 |Platform|SBT|Scala Version|Scala JS Version|
 |---|---|---|---|
-|JVM|```"io.github.shogowada" %% "scala-json-rpc-circe-json-serializer" % "0.9.3"```|2.12||
-|JS|```"io.github.shogowada" %%% "scala-json-rpc-circe-json-serializer" % "0.9.3"```|2.12|0.6.17+|
+|JVM|```"io.github.shogowada" %% "scala-json-rpc-circe-json-serializer" % "1.0.0"```|2.12||
+|JS|```"io.github.shogowada" %%% "scala-json-rpc-circe-json-serializer" % "1.0.0"```|2.12|0.6.28+|
 
 You can use circe-json-serializer to use [circe](https://github.com/circe/circe) as your ```JSONSerializer```.
 

--- a/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONCodecs.scala
+++ b/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONCodecs.scala
@@ -1,0 +1,146 @@
+package io.github.shogowada.scala.jsonrpc.serializers
+
+import io.circe.Decoder.decodeOption
+import io.circe.Encoder.encodeOption
+import io.circe.{Decoder, Encoder, Error, HCursor, Json}
+import io.github.shogowada.scala.jsonrpc.Models._
+import io.github.shogowada.scala.jsonrpc.Types.Id
+
+object CirceJSONCodecs {
+
+  // JSONRPCMethod
+  implicit val encodeJsonRpcMethod: Encoder[JSONRPCMethod] = (jsonRpcMethod: JSONRPCMethod) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcMethod.jsonrpc)),
+      ("method", Json.fromString(jsonRpcMethod.method)),
+    )
+
+  implicit val decodeJsonRpcMethod: Decoder[JSONRPCMethod] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      method <- c.downField("method").as[String]
+    } yield {
+      JSONRPCMethod(jsonrpc, method)
+    }
+  }
+
+  // Id
+  implicit val encodeId: Encoder[Id] = (id: Id) => {
+    id.fold(Json.fromString, Json.fromBigDecimal)
+  }
+
+  implicit val decodeId: Decoder[Id] = (c: HCursor) => {
+    c.as[String] match {
+      case Right(a) => Right(Left(a))
+      case _ => c.as[BigDecimal].map(Right(_))
+    }
+  }
+
+  // JSONRPCId
+  implicit val encodeJsonRpcId: Encoder[JSONRPCId] = (jsonRpcId: JSONRPCId) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcId.jsonrpc)),
+      ("id", encodeId(jsonRpcId.id)),
+    )
+
+  implicit val decodeJsonRpcId: Decoder[JSONRPCId] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      id <- c.downField("id").as[Id]
+    } yield {
+      JSONRPCId(jsonrpc, id)
+    }
+  }
+
+  // JSONRPCRequest
+  implicit def encodeJsonRpcRequest[T](implicit encoder: Encoder[T]): Encoder[JSONRPCRequest[T]] = (jsonRpcRequest: JSONRPCRequest[T]) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcRequest.jsonrpc)),
+      ("id", encodeId(jsonRpcRequest.id)),
+      ("method", Json.fromString(jsonRpcRequest.method)),
+      ("params", encoder(jsonRpcRequest.params))
+    )
+
+  implicit def decodeJsonRpcRequest[T](implicit decoder: Decoder[T]): Decoder[JSONRPCRequest[T]] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      id <- c.downField("id").as[Id]
+      method <- c.downField("method").as[String]
+      params <- c.downField("params").as[T]
+    } yield {
+      JSONRPCRequest(jsonrpc, id, method, params)
+    }
+  }
+
+  // JSONRPCNotification
+  implicit def encodeJsonRpcNotification[T](implicit encoder: Encoder[T]): Encoder[JSONRPCNotification[T]] = (jsonRpcNotification: JSONRPCNotification[T]) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcNotification.jsonrpc)),
+      ("method", Json.fromString(jsonRpcNotification.method)),
+      ("params", encoder(jsonRpcNotification.params))
+    )
+
+  implicit def decodeJsonRpcNotification[T](implicit decoder: Decoder[T]): Decoder[JSONRPCNotification[T]] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      method <- c.downField("method").as[String]
+      params <- c.downField("params").as[T]
+    } yield {
+      JSONRPCNotification(jsonrpc, method, params)
+    }
+  }
+
+  // JSONRPCResultResponse
+  implicit def encodeJsonRpcResultResponse[T](implicit encoder: Encoder[T]): Encoder[JSONRPCResultResponse[T]] = (jsonRpcResultResponse: JSONRPCResultResponse[T]) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcResultResponse.jsonrpc)),
+      ("id", encodeId(jsonRpcResultResponse.id)),
+      ("result", encoder(jsonRpcResultResponse.result))
+    )
+
+  implicit def decodeJsonRpcResultResponse[T](implicit decoder: Decoder[T]): Decoder[JSONRPCResultResponse[T]] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      id <- c.downField("id").as[Id]
+      result <- c.downField("result").as[T]
+    } yield {
+      JSONRPCResultResponse(jsonrpc, id, result)
+    }
+  }
+
+  // JSONRPCError
+  implicit def encodeJsonRpcError[T](implicit encoder: Encoder[T]): Encoder[JSONRPCError[T]] = (jsonRpcError: JSONRPCError[T]) =>
+    Json.obj(
+      ("code", Json.fromInt(jsonRpcError.code)),
+      ("message", Json.fromString(jsonRpcError.message)),
+      ("data", encodeOption[T].apply(jsonRpcError.data))
+    )
+
+  implicit def decodeJsonRpcError[T](implicit decoder: Decoder[T]): Decoder[JSONRPCError[T]] = (c: HCursor) => {
+    for {
+      code <- c.downField("code").as[Int]
+      message <- c.downField("message").as[String]
+      data <- c.downField("data").as[Option[T]]
+    } yield {
+      JSONRPCError(code, message, data)
+    }
+  }
+
+  // JSONRPCErrorResponse
+  implicit def encodeJsonRpcErrorResponse[T](implicit encoder: Encoder[T]): Encoder[JSONRPCErrorResponse[T]] = (jsonRpcErrorResponse: JSONRPCErrorResponse[T]) =>
+    Json.obj(
+      ("jsonrpc", Json.fromString(jsonRpcErrorResponse.jsonrpc)),
+      ("id", encodeId(jsonRpcErrorResponse.id)),
+      ("error", encodeJsonRpcError[T].apply(jsonRpcErrorResponse.error))
+    )
+
+  implicit def decodeJsonRpcErrorResponse[T](implicit decoder: Decoder[T]): Decoder[JSONRPCErrorResponse[T]] = (c: HCursor) => {
+    for {
+      jsonrpc <- c.downField("jsonrpc").as[String]
+      id <- c.downField("id").as[Id]
+      error <- c.downField("error").as[JSONRPCError[T]]
+    } yield {
+      JSONRPCErrorResponse(jsonrpc, id, error)
+    }
+  }
+}

--- a/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializer.scala
+++ b/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializer.scala
@@ -34,7 +34,7 @@ object CirceJSONSerializerMacro {
     c.Expr[Option[String]](
       q"""
           {
-            import io.github.shogowada.scala.jsonrpc.serializer.CirceJSONCodecs._
+            import io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCodecs._
             scala.util.Try(io.circe.Printer.noSpaces.pretty(io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCoder.encode($value))).toOption
           }
           """
@@ -49,7 +49,7 @@ object CirceJSONSerializerMacro {
     c.Expr[Option[T]](
       q"""
           {
-            import io.github.shogowada.scala.jsonrpc.serializer.CirceJSONCodecs._
+            import io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCodecs._
             io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCoder.decode[$deserializeType]($json).toOption
           }
           """

--- a/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializer.scala
+++ b/circe-json-serializer/shared/src/main/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializer.scala
@@ -34,7 +34,7 @@ object CirceJSONSerializerMacro {
     c.Expr[Option[String]](
       q"""
           {
-            import io.circe.generic.auto._
+            import io.github.shogowada.scala.jsonrpc.serializer.CirceJSONCodecs._
             scala.util.Try(io.circe.Printer.noSpaces.pretty(io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCoder.encode($value))).toOption
           }
           """
@@ -49,7 +49,7 @@ object CirceJSONSerializerMacro {
     c.Expr[Option[T]](
       q"""
           {
-            import io.circe.generic.auto._
+            import io.github.shogowada.scala.jsonrpc.serializer.CirceJSONCodecs._
             io.github.shogowada.scala.jsonrpc.serializers.CirceJSONCoder.decode[$deserializeType]($json).toOption
           }
           """

--- a/circe-json-serializer/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializerTest.scala
+++ b/circe-json-serializer/shared/src/test/scala/io/github/shogowada/scala/jsonrpc/serializers/CirceJSONSerializerTest.scala
@@ -1,6 +1,7 @@
 package io.github.shogowada.scala.jsonrpc.serializers
 
 import org.scalatest.{FreeSpec, Matchers, OneInstancePerTest}
+import io.circe.generic.auto._
 
 class CirceJSONSerializerTest extends FreeSpec
     with OneInstancePerTest

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
-addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
+addSbtPlugin("com.vmunier" % "sbt-web-scalajs" % "1.0.9-0.6")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.8.0")
-addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.8.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.15.0-0.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.15.0-0.6")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/upickle-json-serializer/README.md
+++ b/upickle-json-serializer/README.md
@@ -2,8 +2,8 @@
 
 |Platform|SBT|Scala Version|Scala JS Version|
 |---|---|---|---|
-|JVM|```"io.github.shogowada" %% "scala-json-rpc-upickle-json-serializer" % "0.9.3"```|2.12||
-|JS|```"io.github.shogowada" %%% "scala-json-rpc-upickle-json-serializer" % "0.9.3"```|2.12|0.6.17+|
+|JVM|```"io.github.shogowada" %% "scala-json-rpc-upickle-json-serializer" % "1.0.0"```|2.12||
+|JS|```"io.github.shogowada" %%% "scala-json-rpc-upickle-json-serializer" % "1.0.0"```|2.12|0.6.28+|
 
 You can use upickle-json-serializer to use upickle as your ```JSONSerializer```.
 


### PR DESCRIPTION
Apologies for this but it doesn't actually compile properly. It's throwing this error:
object serializer is not a member of package io.github.shogowada.scala.jsonrpc

Which if I use the updated CirceJSONSerializer in my own code works just fine. Maybe you might know where serializer comes from. Anyway the compile time performance improvement is worth the trouble.

From 10 minutes -> 30 seconds if you have 100 or so models.