### PR TITLE
Add link to an alternative library

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 **⚠️ This project is not maintained anymore, and I'm looking for a kind person who can take it over from me.  
 If you can inherit this project, please send a pull request to this README.md linking to your project so that we can direct people to the new home.**
 
+Alternatively, you could use [Automorph](https://automorph.org) which provides very similar functionality.
+
 master: [![Master Build Status](https://travis-ci.org/shogowada/scala-json-rpc.svg?branch=master)](https://travis-ci.org/shogowada/scala-json-rpc)
 
 Let your servers and clients communicate over function calls!


### PR DESCRIPTION
Hi

[Automorph](https://automorph.org) is a Scala RPC library which is directly inspired by scala-json-rpc and provides most of the relevant functionality (excluding bidirectional calls and ScalaJS support at this moment). Perhaps it might be useful to mention it as an alternative. Any reviews or suggestions are very welcome.

Thanks

m.
